### PR TITLE
refactor digitalocean to use nginx reverse proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,12 @@ Each cloud platform will follow the same design pattern, that being:
 
 **3.** Download and install the latest Code Server release via native package manager.
 
+**4.** Import user's SSH keys from their GitHub account for easy SSH access.
+
 ## Future Features:
 The current ideas for future iterations are:
 
-**1.** Implement more platforms. Possibly AWS next.
+**1.** Implement more platforms. GCP and Azure.
 
 **2.** Add automation for installing dev tools (possibly Ansible).
 

--- a/digitalocean/README.md
+++ b/digitalocean/README.md
@@ -1,9 +1,9 @@
 # Digital Ocean
 You will need to export your [Digital Ocean API token](https://www.digitalocean.com/docs/api/create-personal-access-token/) as `DIGITALOCEAN_TOKEN` to authenticate Terraform.
 
-By default, this stack builds a [load balancer](https://www.digitalocean.com/docs/networking/load-balancers/) which accepts and passes HTTP traffic through to the Code Server port `:8080` on the droplet. For optimal security, I recommend using a TLS-certified domain and forcing HTTPS on the load balancer. An easy managed way to achieve this on Digital Ocean can be found [here](https://www.digitalocean.com/docs/networking/load-balancers/how-to/ssl-termination/).
+By default, this stack builds a Droplet with an NGINX reverse proxy which accepts and passes HTTP traffic through to the Code Server port `:8080` on the instance. For optimal security, I recommend using a TLS-certified domain against the instance public IP. This can be easily added into the existing NGINX webserver with the [following guide](https://www.scaleway.com/en/docs/how-to-configure-nginx-reverse-proxy/#-Adding-TLS-to-your-Nginx-Reverse-Proxy-using-Lets-Encrypt).
 
-_**FYI:** Digital Ocean user data can take a few minutes to execute sometimes. If the Code Server endpoint initially returns a 503, this just means the user data hasn't finished executing yet._
+_**FYI:** Digital Ocean user data can take a few minutes to execute sometimes. If the Code Server endpoint initially returns a 503 or you are unable to SSH in, this just means the user data hasn't finished executing yet._
 
 ## Digital Ocean parameters in [terraform.tvfars](terraform.tfvars):
 
@@ -43,32 +43,4 @@ _**FYI:** Digital Ocean user data can take a few minutes to execute sometimes. I
 
 **storage_size:** The size *(in GB)* of the persistent disk that will be mounted to `/home`.
 
-**ssh_key_id:** Your [Digital Ocean SSH key ID](https://developers.digitalocean.com/documentation/v2/#list-all-keys). These are 8-digit numbers that map to SSH keys linked on your Digital Ocean account and are required to authenticate connections to the droplet.
-
-To find your SSH Key ID, run the following command, replacing `DO_API_TOKEN` with your Digital Ocean API token.
-
-```
-curl -X GET -H "Content-Type: application/json" -H "Authorization: Bearer DO_API_TOKEN" "https://api.digitalocean.com/v2/account/keys"
-````
-
-The response body will look like this. Grab the 8-digit ID number.
-
-```
-{
-  "ssh_keys": [
-    {
-      "id": 512189,
-      "fingerprint": "3b:16:bf:e4:8b:00:8b:b8:59:8c:a9:d3:f0:19:45:fa",
-      "public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAQQDDHr/jh2Jy4yALcK4JyWbVkPRaWmhck3IgCoeOO3z1e2dBowLh64QAM+Qb72pxekALga2oi4GvT+TlWNhzPH4V example",
-      "name": "My SSH Public Key"
-    }
-  ],
-  "links": {
-  },
-  "meta": {
-    "total": 1
-  }
-}
-```
-
-If you have not added your SSH key to your Digital Ocean account, instructions to do so can be found [here](https://www.digitalocean.com/docs/droplets/how-to/add-ssh-keys/to-account/).
+**github_username:** Your GitHub username. This will import the SSH keys associated with your GitHub account to the created user so you can SSH into the EC2 instance if needed.

--- a/digitalocean/outputs.tf
+++ b/digitalocean/outputs.tf
@@ -1,5 +1,5 @@
 output "ip_address" {
-  value = digitalocean_loadbalancer.lb.ip
+  value = digitalocean_droplet.droplet.ipv4_address
 }
 
 output "sudo_password" {

--- a/digitalocean/terraform.tfvars
+++ b/digitalocean/terraform.tfvars
@@ -13,5 +13,5 @@ droplet_size = "s-2vcpu-2gb"
 # /home drive size
 storage_size = 20
 
-# SSH key ID
-ssh_key_id = 01234567
+# GitHub username
+github_username = "github_username"

--- a/digitalocean/variables.tf
+++ b/digitalocean/variables.tf
@@ -18,6 +18,6 @@ variable "storage_size" {
   type = number
 }
 
-variable "ssh_key_id" {
-  type = number
+variable "github_username" {
+  type = string
 }


### PR DESCRIPTION
Replaces load balancer with a simple NGINX reverse proxy on the droplet. For this demo repo, simple is better!

Also deprecated using Digital Ocean SSH keys in favour of pulling keys from GitHub user account.