### PR TITLE
Fix: Keep up with module updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ module "code-server" {
   oauth2_client_secret = var.oauth2_client_secret
   oauth2_provider      = "google"
   region               = "us-east-1"
-  route_53_zone_id     = "Z23ABC4XYZL05B"
+  route53_zone_id      = "Z23ABC4XYZL05B"
   storage_size         = 20
   username             = "coder"
 }

--- a/main.tf
+++ b/main.tf
@@ -108,7 +108,7 @@ module "ec2_instance" {
 }
 
 resource "aws_eip" "ip" {
-  instance = module.ec2_instance.id[0]
+  instance = module.ec2_instance.id
   vpc      = true
 }
 

--- a/main.tf
+++ b/main.tf
@@ -83,7 +83,7 @@ module "ec2_instance" {
   name                        = var.hostname
   ami                         = data.aws_ami.ubuntu.id
   instance_type               = var.instance_size
-  subnet_ids                  = module.vpc.public_subnets
+  subnet_id                   = module.vpc.public_subnets[0]
   vpc_security_group_ids      = [module.security_group.this_security_group_id]
   associate_public_ip_address = true
   user_data                   = data.template_file.user_data.rendered

--- a/main.tf
+++ b/main.tf
@@ -84,7 +84,7 @@ module "ec2_instance" {
   ami                         = data.aws_ami.ubuntu.id
   instance_type               = var.instance_size
   subnet_id                   = module.vpc.public_subnets[0]
-  vpc_security_group_ids      = [module.security_group.this_security_group_id]
+  vpc_security_group_ids      = [module.security_group.security_group_id]
   associate_public_ip_address = true
   user_data                   = data.template_file.user_data.rendered
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -29,7 +29,7 @@ output "public_subnet_cidr_blocks" {
 }
 
 output "security_group_id" {
-  value       = module.security_group.this_security_group_id
+  value       = module.security_group.security_group_id
   description = "The ID of the security group"
 }
 

--- a/user_data.tpl
+++ b/user_data.tpl
@@ -61,7 +61,7 @@ enable_code_server() {
 
 install_oauth2_proxy() {
   OAUTH2_PROXY_RELEASE=$(curl -s https://api.github.com/repos/oauth2-proxy/oauth2-proxy/releases/latest \
-  | jq -r ".assets[] | select(.name | test(\"linux-amd64.go\")) | .browser_download_url")
+  | jq -r ".assets[] | select(.name | test(\"linux-amd64.tar\")) | .browser_download_url")
   TARBALL=$(echo "$OAUTH2_PROXY_RELEASE" | awk -F'/' '{print $9}')
 
   wget "$OAUTH2_PROXY_RELEASE"


### PR DESCRIPTION
Thanks for creating the repository! I've learned a lot from your work.
I tried to use this module, but it didn't work as is. so I fixed a few problems.

# What has changed

- Fix this_security_group_id to security_group_id
  - this_security_group_id is missing in [security_group module outputs](https://registry.terraform.io/modules/terraform-aws-modules/security-group/aws/latest?tab=outputs)
- Fix subnet_ids to subnet_id
  - subnet_ids is missing in [ec2-instance module inputs](https://registry.terraform.io/modules/terraform-aws-modules/ec2-instance/aws/latest?tab=inputs)
- Fix array to string for  module.ec2_instance.id
- fix a problem of not being able to find the oauth2-proxy binary to download
- Fix route_53_zone_id to route53_zone_id in usage