### PR TITLE
Add azs inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ terraform apply \
 | oauth2_client_secret | OAuth2 client secret key for chosen OAuth2 provider | `string` | n/a | yes |
 | oauth2_provider | OAuth2 provider | `string` | n/a | yes |
 | region | AWS regional endpoint | `string` | `"us-east-1"` | no |
+| azs | A list of availability zones names or ids in the region | `list(string)` | `["${var.region}a", "${var.region}b", "${var.region}c"]` | no |
 | route53_zone_id | Route53 hosted zone ID for `domain_name` | `string` | n/a | yes |
 | storage_size | Size (in GB) for immutable EBS volume mounted to `/home` | `number` | `20` | no |
 | username | Username for the non-root user on the EC2 instance | `string` | `"coder"` | no |

--- a/main.tf
+++ b/main.tf
@@ -8,6 +8,7 @@ locals {
     Name      = "${var.github_username}-code-server"
     Terraform = true
   }
+  azs = length(var.azs) != 0 ? var.azs : ["${var.region}a", "${var.region}b", "${var.region}c"]
 }
 
 # Passwords
@@ -27,7 +28,7 @@ module "vpc" {
   source = "terraform-aws-modules/vpc/aws"
 
   cidr           = "10.0.0.0/16"
-  azs            = ["${var.region}a", "${var.region}b", "${var.region}c"]
+  azs            = local.azs
   public_subnets = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
   tags           = local.tags
 }

--- a/variables.tf
+++ b/variables.tf
@@ -47,6 +47,12 @@ variable "region" {
   default     = "us-east-1"
 }
 
+variable "azs" {
+  type        = list(string)
+  description = "A list of availability zones names or ids in the region. default is `[\"${var.region}a\", \"${var.region}b\", \"${var.region}c\"]`"
+  default     = []
+}
+
 variable "route53_zone_id" {
   type        = string
   description = "Route53 hosted zone ID for `domain_name`"


### PR DESCRIPTION
# What has changed
- add `azs` variables to inputs.

# Why
I am using it in the ap-northeast-1 region, but this region does not have `ap-northeast-1b` in the availability zones, so I could not use it as is. (a, c, and d are available).
So I added a non-required option,  so that if it is not set, it will still work as before.
